### PR TITLE
Upload beta

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ psycopg2-binary==2.9.9
 PyMySQL==1.1.1
 python-decouple==3.8
 sqlparse==0.5.1
+mutagen==1.4.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ psycopg2-binary==2.9.9
 PyMySQL==1.1.1
 python-decouple==3.8
 sqlparse==0.5.1
-mutagen==1.4.7
+mutagen==1.47.0

--- a/website/forms.py
+++ b/website/forms.py
@@ -2,6 +2,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django import forms
 from .models import UserProfile, Sample
+import os
 
 
 

--- a/website/forms.py
+++ b/website/forms.py
@@ -1,9 +1,7 @@
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from django import forms
-from .models import UserProfile 
-
-
+from .models import UserProfile, Sample
 
 
 
@@ -52,3 +50,33 @@ class SignUpForm(UserCreationForm):
 				numberOfFollowers=0  # default to 0
 			)
 		return user
+
+class SampleUploadForm(forms.ModelForm):
+    filelocation = forms.FilePathField(allow_files = True, allow_folders = False, path = 'SampleShare/')
+
+    class Meta:
+        model = Sample
+        fields = ['sampleName', 'fileLocation','isPublic',]
+        widgets = {
+            'fileLocation': forms.TextInput(attrs={'placeholder': 'Enter file path'}),
+			'isPublic': forms.CheckboxInput(),
+        }
+    def clean_file_location(self):
+        file_location = self.cleaned_data.get('fileLocation')
+
+        if not os.path.exists(fileLocation):
+            raise forms.ValidationError('File path does not exist.')
+
+        if not os.path.isfile(fileLocation):
+            raise forms.ValidationError('The path must point to a file, not a directory.')
+        
+        valid_extensions = ['.mp3', '.wav']
+        file_extension = os.path.splitext(fileLocation)[1]
+
+        if file_extension.lower() not in valid_extensions:
+            raise forms.ValidationError(f'Invalid file type. Accepted types: {", ".join(valid_extensions)}')
+
+        if not os.access(file_location, os.R_OK):
+            raise forms.ValidationError('The file is not readable.')
+
+        return file_location

--- a/website/templates/navbar.html
+++ b/website/templates/navbar.html
@@ -11,7 +11,7 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'logout' %}">Log out</a>
         </li>
-        <button type="button" hred="{% url 'upload' %}" class="btn btn-outline-danger">Upload</button>
+        <button type="button" href="{% url 'upload' %}" class="btn btn-outline-danger">Upload</button>
         {% else %}
         <li class="nav-item">
           <a class="nav-link" href="{% url 'register' %}">Register</a>

--- a/website/templates/navbar.html
+++ b/website/templates/navbar.html
@@ -11,7 +11,7 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'logout' %}">Log out</a>
         </li>
-        <button type="button" href="{% url 'upload' %}" class="btn btn-outline-danger">Upload</button>
+        <button type="button" onclick="window.location.href='{% url 'upload' %}'" class="btn btn-outline-danger">Upload</button>
         {% else %}
         <li class="nav-item">
           <a class="nav-link" href="{% url 'register' %}">Register</a>

--- a/website/templates/navbar.html
+++ b/website/templates/navbar.html
@@ -11,6 +11,7 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'logout' %}">Log out</a>
         </li>
+        <button type="button" hred="{% url 'upload' %}" class="btn btn-outline-danger">Upload</button>
         {% else %}
         <li class="nav-item">
           <a class="nav-link" href="{% url 'register' %}">Register</a>

--- a/website/templates/upload.html
+++ b/website/templates/upload.html
@@ -1,0 +1,132 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Upload Sample</title>
+    <style>
+        /* Basic styling for drag-and-drop area */
+        #drop-zone {
+            width: 70%;
+            height: 150px;
+            border: 2px dashed #ccc;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 20px;
+            color: #666;
+        }
+        .file-item {
+            margin: 10px 0;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>Upload Samples</h1>
+
+    <div id="drop-zone">Drag and drop files here</div>
+    <ul id="file-list"></ul>
+
+    <form id="SampleUploadForm" method="POST" enctype="multipart/form-data">
+        {% csrf_token %}
+        <label>
+            <input type="checkbox" name="is_public" id="is-public">
+            Public?
+        </label>
+        <br><br>
+        <button type="submit" id="submit-btn">Submit</button>
+        <button type="button" onclick="window.location.href='/'">Cancel</button>
+    </form>
+
+    {% if messages %}
+    <ul class="messages">
+        {% for message in messages %}
+            <li class="{{ message.tags }}">{{ message }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+
+    <script>
+        const dropZone = document.getElementById('drop-zone');
+        const fileList = document.getElementById('file-list');
+        let files = [];  // Store files as they are added
+
+        // Handle drag-and-drop
+        dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.style.borderColor = 'green';  // Highlight zone
+        });
+
+        dropZone.addEventListener('dragleave', () => {
+            dropZone.style.borderColor = '#ccc';  // Revert border
+        });
+
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.style.borderColor = '#ccc';  // Revert border
+
+            const droppedFiles = Array.from(e.dataTransfer.files);
+            droppedFiles.forEach(file => validateAndAddFile(file));
+        });
+
+        // Validate file type and size before adding to the list
+        function validateAndAddFile(file) {
+            const validExtensions = ['.mp3', '.wav'];
+            const fileExtension = file.name.split('.').pop().toLowerCase();
+            const validType = validExtensions.includes('.' + fileExtension);
+
+            if (!validType) {
+                alert(`Invalid file type: ${file.name}. Only .mp3 or .wav files are accepted.`);
+                return;
+            }
+
+            const audio = document.createElement('audio');
+            const fileURL = URL.createObjectURL(file);
+
+            audio.src = fileURL;
+            audio.addEventListener('loadedmetadata', function () {
+                const duration = audio.duration;
+
+                if (duration > 6) {
+                    alert(`File is too long: ${file.name}. Must be less than 6 seconds.`);
+                    URL.revokeObjectURL(fileURL);  // Clean up URL reference
+                } 
+                else {
+                    files.push(file);  // Add to array if valid
+                    displayFileList();
+                }
+            });
+
+            audio.onerror = function() {
+                alert(`Could not load audio file: ${file.name}.`);
+                URL.revokeObjectURL(fileURL);  // Clean up URL reference
+            };
+        }
+
+        // Display list of files
+        function displayFileList() {
+            fileList.innerHTML = '';
+            files.forEach((file, index) => {
+                const listItem = document.createElement('li');
+                listItem.className = 'file-item';
+                listItem.textContent = file.name + ' ';
+                const removeButton = document.createElement('button');
+                removeButton.textContent = 'Remove';
+                removeButton.onclick = () => removeFile(index);
+                listItem.appendChild(removeButton);
+                fileList.appendChild(listItem);
+            });
+        }
+
+        // Remove file from the list
+        function removeFile(index) {
+            files.splice(index, 1);
+            displayFileList();
+        }
+    </script>
+
+</body>
+{% endblock %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('login/', views.login_user, name='login'),
     path('logout/', views.logout_user, name='logout'),
     path('register/', views.register_user, name='register'),
-
+    path('upload/', views.upload, name='upload'),
+    
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -78,37 +78,6 @@ def register_user(request):
 
 
 #Upload Samples
-def move_uploaded_sample(upload, userProfiles):
-    temp_path = f'/tmp/{uploaded_sample.name}'
-    
-    with open(temp_path, 'wb+') as temp_file:
-        for chunk in uploaded_sample.chunks():
-            temp_file.write(chunk)
-
-    file_extension = os.path.splitext(uploaded_sample.name)[1]
-    is_valid, error_message = validate_length(temp_path, file_extension)
-    if not is_valid:
-        os.remove(temp_path)
-        return False, error_message
-
-    final_path = f'media/uploads/{userProfiles}/{uploaded_sample.name}'
-    with open(final_path, 'wb+') as final_file:
-        for chunk in uploaded_sample.chunks():
-            final_file.write(chunk)
-
-    return final_path
-
-def validate_length(temp_path, file_extension):
-    if file_extension.lower() == '.mp3':
-        audio = MP3(temp_path)
-        if audio.info.length > 6.0:
-            return False, 'The Sample must be no longer than 6 seconds.'
-    elif file_extension.lower() == '.wav':
-        audio = WAVE(temp_path)
-        if audio.info.length > 6.0:
-            return False, 'The Sample must be no longer than 6 seconds.'
-    return True, None
-
 def upload(request):
     if not request.user.is_authenticated:
         messages.error(request, 'You must be logged in to upload a sample.')

--- a/website/views.py
+++ b/website/views.py
@@ -93,7 +93,7 @@ def upload(request):
         except UserProfile.DoesNotExist:
             messages.error(request, 'No profile found for the current user.')
             return redirect('upload')
-            
+
             sample = Sample(
                 userProfile=user_profile,  # Assign logged-in user's profile
                 sampleName=uploaded_file.name,


### PR DESCRIPTION


Changes

-Created a url, view, form, and html template to upload new samples
-Created a drag-and-drop html upload that automatically throws errors for inappropriate files and can parse through multiple files at once.
-Created a new option in the navbar on the logged in users' end that links to the upload page.

Update: Requirements amended.

Functionality
The user can now upload their samples to the website without including a file that isn't planned for in our system.

Improvements & Future Issues
Currently users cannot see their uploaded samples, but this will be added after the inclusion of the media player and the user profiles. Users also cannot currently delete the samples they've uploaded as well. Samples can't be uploaded to Posts yet, but this will be resolved after Posts are pushed to the main dev branch.