### PR TITLE
samples crud operations

### DIFF
--- a/website/forms.py
+++ b/website/forms.py
@@ -8,6 +8,33 @@ class SampleForm(forms.ModelForm):
     class Meta:
         model = Sample
         fields = ["sampleName", "audioFile", "isPublic", "userProfiles"]
+        widgets = {
+            "userProfiles": forms.TextInput(
+                attrs={
+                    "class": "form-control",
+                    "value": "",
+                    "id": "user",
+                    "type": "hidden",
+                }
+            )
+        }
+
+
+class SampleEditForm(forms.ModelForm):
+    class Meta:
+        model = Sample
+        fields = ["sampleName", "isPublic", "userProfiles"]
+        labels = {"isPublic": "Make Sample Public?"}
+        widgets = {
+            "userProfiles": forms.TextInput(
+                attrs={
+                    "class": "form-control",
+                    "value": "",
+                    "id": "user",
+                    "type": "hidden",
+                }
+            )
+        }
 
 
 class SignUpForm(UserCreationForm):
@@ -103,9 +130,6 @@ class ProfileForm(forms.ModelForm):
     class Meta:
         model = UserProfile
         fields = ["bio", "userPhoto"]
-
-
-# ---------------------------------------------------
 
 
 # ----------------------Comment Code------------------#\

--- a/website/templates/edit_samples.html
+++ b/website/templates/edit_samples.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block content %}
+
+<!-- users uploaded samples -->
+<h1>Your Uploaded Samples</h1>
+
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Sample Name</th>
+      <th scope="col">Privacy Status</th>
+      <th scope="col">Edit/Delete</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for sample in user_samples %}
+    <tr>
+      <th scope="row">{{ forloop.counter }}</th>
+      <td>{{ sample.sampleName }}</td>
+      <td>
+        {% if sample.isPublic %}
+        <span class="test-success">Public</span>
+        {% else %}
+        <span class="text-danger">Private</span>
+        {% endif %}
+      </td>
+      <td>
+        <a href="?update={{ sample.id }}" class="btn btn-primary">Edit</a>
+        <a href="{% url 'delete_user_sample' sample.id %}" class="btn btn-danger"
+          onclick="return confirm('Are you sure you want to permanently delete this sample?');">Delete</a>
+
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% if form %}
+<h2>Update Sample: {{ form.instance.sampleName }}</h2>
+<form method="POST" enctype="multipart/form-data">
+  {% csrf_token %}
+  {{ form.as_p }}
+
+  <input type="hidden" name="sample_id" value="{{ form.instance.id }}">
+
+  <button type="submit" class="btn btn-success">Save Changes</button>
+  <a href="{% url 'edit_samples' %}" class="btn btn-secondary">Cancel</a>
+
+  <input type="hidden" name="sample_id" value="{{ form.instance.id }}">
+
+  <script>
+    var name = "{{ user.userprofile.id }}";
+    document.getElementById("user").value =
+      name;
+  </script>
+
+
+</form>
+{% endif %}
+
+{% endblock%}

--- a/website/templates/profile_page.html
+++ b/website/templates/profile_page.html
@@ -22,6 +22,7 @@
 
   <!-- Link to Edit Profile -->
   <a href="{% url 'edit_profile' %}" class="btn btn-primary">Edit Profile</a>
+  <a href="{% url 'edit_samples' %}" class="btn btn-primary">Edit Samples</a>
 
 
 

--- a/website/templates/sample_player.html
+++ b/website/templates/sample_player.html
@@ -5,17 +5,25 @@
 <h2> Uploaded Samples </h2>
 
 {% if query_all_sample %}
-<ul>
-  {% for sample in query_all_sample %}
-    <li>
-      <h3> {{sample.sampleName}}</h3>
-      <div class="player-container"> 
-        <button onclick="playPause('{{ sample.audioFile.url }}')" id="playBtn" class="btn btn-primary"> Play </button>
-      </div>
-    <!-- <button onclick="playSample('{{sample.audioFile.url}}')" class="btn btn-primary"> Play Sample </button> -->
-    </li>
+<table class="table table-hover">
+  <thead> 
+    <tr> 
+      <th scope="col">Sample Names</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for sample in query_all_sample %}
+    <tr>
+      <td scope="row">{{ sample.sampleName }}</td>
+      <td scope="row"> 
+        <div class="player-container"> 
+          <button onclick="playPause('{{ sample.audioFile.url }}')" id="playBtn" class="btn btn-primary"> Play </button>
+        </div>
+      </td>
+    </tr>
+  </tbody>
   {% endfor %}
-</ul>
+
 {%else%}
   <p>No Samples Uploaded!</p>
 {%endif%}
@@ -23,11 +31,6 @@
 <!-- howler lib + the call to the sample player -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.3/howler.min.js"></script>
 <script src="{% static 'js/sample_player.js' %}"</script>
-<script>
-  var name = "{{ user.userprofile.id }}";
-  document.getElementById("user").value =
-    name;
-</script>
 
 {% endblock %}
 

--- a/website/templates/sample_player.html
+++ b/website/templates/sample_player.html
@@ -23,6 +23,11 @@
 <!-- howler lib + the call to the sample player -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.2.3/howler.min.js"></script>
 <script src="{% static 'js/sample_player.js' %}"</script>
+<script>
+  var name = "{{ user.userprofile.id }}";
+  document.getElementById("user").value =
+    name;
+</script>
 
 {% endblock %}
 

--- a/website/templates/upload.html
+++ b/website/templates/upload.html
@@ -37,6 +37,12 @@
         <br><br>
         <button type="submit" id="submit-btn">Upload</button>
         <button type="button" onclick="window.location.href='/'">Cancel</button>
+        <script>
+          var name = "{{ user.userprofile.id }}";
+          document.getElementById("user").value =
+            name;
+        </script>
+        
     </form>
 </body>
 {% endblock %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -19,6 +19,12 @@ urlpatterns = [
     path("delete-account/", views.delete_account, name="delete_account"),
     # -------Samples/Uploads Links------------#
     path("upload/", views.upload, name="upload"),
+    path("edit_samples/", views.update_user_samples, name="edit_samples"),
+    path(
+        "delete_user_sample/<int:sample_id>/",
+        views.delete_user_sample,
+        name="delete_user_sample",
+    ),
     path("sample/", views.sample_player, name="sample_player"),
     # -------Posts Links------------#
     path("posts/", views.posts, name="posts"),

--- a/website/views.py
+++ b/website/views.py
@@ -3,7 +3,6 @@ from django.http.request import is_same_domain
 from django.http.response import HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import Http404
-from mutagen.wave import delete
 from .models import Sample, UserProfile, Post, Comment
 from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages

--- a/website/views.py
+++ b/website/views.py
@@ -3,10 +3,11 @@ from django.http.request import is_same_domain
 from django.http.response import HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import Http404
+from mutagen.wave import delete
 from .models import Sample, UserProfile, Post, Comment
 from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages
-from .forms import SampleForm, SignUpForm, PostForm, CommentForm
+from .forms import SampleEditForm, SampleForm, SignUpForm, PostForm, CommentForm
 from django.contrib.auth.models import User
 from django.views.generic import CreateView
 from .forms import ProfileForm
@@ -100,7 +101,7 @@ def register_user(request):
     return render(request, "register.html", {"form": form})
 
 
-# --------------------------------------------------------------------#
+# ----------------------------Sample Functionality---------------------------------------#
 
 
 def upload(request):
@@ -119,7 +120,63 @@ def upload(request):
         return redirect("login")
 
 
-# --------------------------------------------------------------------#
+def update_user_samples(request):
+    if request.user.is_authenticated:
+        user_samples = Sample.objects.filter(userProfiles__user=request.user)
+        form = None
+
+        if request.method == "POST":
+            sample_id_to_update = request.POST.get("sample_id")
+            if sample_id_to_update:
+                sample = get_object_or_404(
+                    Sample, pk=sample_id_to_update, userProfiles__user=request.user
+                )
+                form = SampleEditForm(request.POST, instance=sample)
+                form.instance.audioFile = sample.audioFile
+
+                if form.is_valid():
+                    form.save()
+                    messages.success(
+                        request, f"{sample.sampleName} updated successfully!"
+                    )
+                    return redirect("edit_samples")
+        else:
+            sample_id_to_update = request.GET.get("update")
+            if sample_id_to_update:
+                sample = get_object_or_404(
+                    Sample, pk=sample_id_to_update, userProfiles__user=request.user
+                )
+                form = SampleEditForm(instance=sample)
+
+        return render(
+            request,
+            "edit_samples.html",
+            {"user_samples": user_samples, "form": form},
+        )
+    else:
+        messages.error(request, "You need to be logged in to access this page.")
+        return redirect("login")
+
+
+def delete_user_sample(request, sample_id):
+    if request.user.is_authenticated:
+        try:
+            sample_to_delete = get_object_or_404(
+                Sample, id=sample_id, userProfiles__user=request.user
+            )
+            audio_file_path = sample_to_delete.audioFile.path
+            sample_to_delete.delete()
+
+            if os.path.exists(audio_file_path):
+                os.remove(audio_file_path)
+                messages.success(request, "Sample file deleted successfully.")
+        except Exception as e:
+            messages.warning(request, f"An unexpected error occurred: \n {e}")
+    else:
+        messages.error(request, "You need to be logged in!")
+        return redirect("login")
+
+    return redirect("edit_samples")
 
 
 def sample_player(request):
@@ -131,6 +188,9 @@ def sample_player(request):
     else:
         messages.error(request, "You must be logged in to listen to samples.")
         return redirect("login")
+
+
+# --------------------------------------------------------------------#
 
 
 def search_user(request):


### PR DESCRIPTION
**Feature**
- closes #48 
- added crud operations to samples, user can now delete samples, edit the name of a sample and also set the privacy setting.
- the sample edit button was added to the user profile page.

**Testing**
- there was no change to the database so there is no need to delete migration files
- have uploaded samples then head over to your user profile page and there will be an edit samples button
- takes you to a page where a user is allowed to edit or delete there samples.
- when deleting a sample, it does not just delete from the database, it SHOULD also delete the uploaded samples from the media/samples/ directory.

**Other changes to the project**
- there is now a new html page to edit samples
- two new links to edit and delete samples
- i also took the chance to fix #53 
- I also edited the samples page to show samples in a more uniformed way.